### PR TITLE
Prevents window and other autocmd events when switching windows

### DIFF
--- a/plugin/animate.vim
+++ b/plugin/animate.vim
@@ -106,23 +106,21 @@ function! animate#window_delta(width_delta, height_delta) abort
       " Distribute space and clean up our changes to windows
       if g:animate#distribute_space
         " Store the widths
-        set eventignore=all
-        windo if ! &winfixwidth | let nowinfixwidths[winnr()] = 1 | set winfixwidth | endif
+        noautocmd windo if ! &winfixwidth | let nowinfixwidths[winnr()] = 1 | set winfixwidth | endif
         " Restore focus
         call animate#window_focus(self.target_window)
         if winfixheight
-          wincmd =
+          noautocmd wincmd =
         else
           set winfixheight
-          wincmd =
+          noautocmd wincmd =
           set nowinfixheight
         endif
         " Restore the widths
-        windo if has_key(nowinfixwidths, winnr()) | set nowinfixwidth | endif
+        noautocmd windo if has_key(nowinfixwidths, winnr()) | set nowinfixwidth | endif
        
         " Restore focus
         call animate#window_focus(self.target_window)
-        set eventignore=
       endif
     endif
 
@@ -134,22 +132,20 @@ function! animate#window_delta(width_delta, height_delta) abort
       " Distribute space and clean up our changes to windows
       if g:animate#distribute_space
         " Store the heights
-        set eventignore=all
-        windo if ! &winfixheight | let nowinfixheights[winnr()] = 1 | set winfixheight | endif
+        noautocmd windo if ! &winfixheight | let nowinfixheights[winnr()] = 1 | set winfixheight | endif
         " Restore focus
         call animate#window_focus(self.target_window)
         if winfixwidth
           wincmd =
         else
           set winfixwidth
-          wincmd =
+          noautocmd wincmd =
           set nowinfixwidth
         endif
         " Restore the heights
-        windo if has_key(nowinfixheights, winnr()) | set nowinfixheight | endif
+        noautocmd windo if has_key(nowinfixheights, winnr()) | set nowinfixheight | endif
         " Restore focus
         call animate#window_focus(self.target_window)
-        set eventignore=
       endif
     endif
 
@@ -253,7 +249,7 @@ function! animate#window_focus(target_window) abort
   if win_getid(a:target_window) == 0
     return v:false
   else
-    execute a:target_window.'wincmd w'
+    execute 'noautocmd '. a:target_window.'wincmd w'
     return v:true
   endif
 endfunction

--- a/plugin/animate.vim
+++ b/plugin/animate.vim
@@ -106,7 +106,8 @@ function! animate#window_delta(width_delta, height_delta) abort
       " Distribute space and clean up our changes to windows
       if g:animate#distribute_space
         " Store the widths
-        noautocmd windo if ! &winfixwidth | let nowinfixwidths[winnr()] = 1 | set winfixwidth | endif
+        set eventignore=all
+        windo if ! &winfixwidth | let nowinfixwidths[winnr()] = 1 | set winfixwidth | endif
         " Restore focus
         call animate#window_focus(self.target_window)
         if winfixheight
@@ -117,9 +118,11 @@ function! animate#window_delta(width_delta, height_delta) abort
           set nowinfixheight
         endif
         " Restore the widths
-        noautocmd windo if has_key(nowinfixwidths, winnr()) | set nowinfixwidth | endif
+        windo if has_key(nowinfixwidths, winnr()) | set nowinfixwidth | endif
+       
         " Restore focus
         call animate#window_focus(self.target_window)
+        set eventignore=
       endif
     endif
 
@@ -131,7 +134,8 @@ function! animate#window_delta(width_delta, height_delta) abort
       " Distribute space and clean up our changes to windows
       if g:animate#distribute_space
         " Store the heights
-        noautocmd windo if ! &winfixheight | let nowinfixheights[winnr()] = 1 | set winfixheight | endif
+        set eventignore=all
+        windo if ! &winfixheight | let nowinfixheights[winnr()] = 1 | set winfixheight | endif
         " Restore focus
         call animate#window_focus(self.target_window)
         if winfixwidth
@@ -142,9 +146,10 @@ function! animate#window_delta(width_delta, height_delta) abort
           set nowinfixwidth
         endif
         " Restore the heights
-        noautocmd windo if has_key(nowinfixheights, winnr()) | set nowinfixheight | endif
+        windo if has_key(nowinfixheights, winnr()) | set nowinfixheight | endif
         " Restore focus
         call animate#window_focus(self.target_window)
+        set eventignore=
       endif
     endif
 


### PR DESCRIPTION
Thanks for the great plugins!  I ran into a performance issue when combining lens.vim and logic that was dependent on Win/Buf Enter autocmds.  This pull request adds noautocmd to wincmd usage.

 It's not well tested but this PR fixes the performance degradation that I was seeing.


The issue was identified with the following steps before PR:
1) Create multiple splits
2) ```:au! WinEnter * echomsg 123```
3) Switch windows
4) Check log
Output: Many lines of `123`

With a fix in place, there should be only one log statement
