### PR TITLE
Default to ease_in_out_sine easing

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Currently there are 3 easing options available:
 - `animate#ease_linear`
 - `animate#ease_out_quad`
 - `animate#ease_out_cubic`
-- `animate#ease_in_out_sine`
+- `animate#ease_in_out_sine` (default)
 
 To set a custom easing function:
 

--- a/plugin/animate.vim
+++ b/plugin/animate.vim
@@ -37,7 +37,7 @@ endif
 if exists('g:animate#easing_func')
   let g:Animate#Ease = function(g:animate#easing_func)
 else
-  let g:Animate#Ease = function('animate#ease_linear')
+  let g:Animate#Ease = function('animate#ease_in_out_sine')
 endif
 
 let g:animate#timer_ids = {}


### PR DESCRIPTION
As discussed in #6, it makes sense to use sine easing by default.